### PR TITLE
support parsing single param for task

### DIFF
--- a/lib/utils/argv-parse.js
+++ b/lib/utils/argv-parse.js
@@ -14,6 +14,18 @@ function stringToObject (str) {
     value
   }
 }
+
+function parseSingleCmd (input) {
+  const key = '--argv'
+  const idx = input.indexOf(key)
+  if (idx == -1) {
+    return input
+  }
+  else {
+    input = input.slice(0, idx).concat(`${key}=${input.slice(idx + 1).join(' ')}`)
+  }
+  return input
+}
 /**
  * Argvs Parse
  *
@@ -71,7 +83,8 @@ module.exports = ({ inputs, filters, native } = {}) => {
   if (!inputs || inputs.length < 1) {
     return { tasks, mode }
   }
-
+  
+  inputs = parseSingleCmd(inputs)
   inputs.reduce((prev, curr) => {
     const startsWithPrefix = curr.startsWith(prefix) || curr.startsWith(prefix2)
     const _prefix = curr.startsWith(prefix) ? prefix : prefix2


### PR DESCRIPTION
自定义任务支持解析单一参数。
目前fbi对于命令和参数的解析的做法是：
`fbi serve -port=9000 -test deploy -ip=10.11.11.11 -silent`
通过`--key1=value1 --key2=value2`的格式，解析为`{key1: value1, key2:value2}`的参数对象

而在做自定义task的时候，有这样的情况出现：
`fbi lint --argv file1 file2 file3`，即`--argv`后面的所有内容都是任务lint的参数部分，fbi现在不支持这种模式。

情况举例：
使用lint-staged库的时候
```
"lint-staged": {
    "src/**/*.js": [
      "fbi lint --argv",
      "git add"
    ]
  }
```
lint-staged会将git stage中的文件以`file1 file2 file3`的格式追加在`fbi lint --argv`后面