### PR TITLE
fbi add 去除version版本控制逻辑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.5.0](https://github.com/fbi-js/fbi/compare/v4.4.1...v4.5.0) (2021-02-25)
+
+
+### Features
+
+* remove fbi add version logic ([d8c7697](https://github.com/fbi-js/fbi/commit/d8c7697d9b28502cdbe1c919d27513189eb14124))
+
 ### [4.4.1](https://github.com/fbi-js/fbi/compare/v4.4.0...v4.4.1) (2021-02-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fbi",
   "description": "A workflow tool in the command line",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "author": "shaw @neikvon",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -237,12 +237,12 @@ export default class CommandAdd extends Command {
       this.debug('Save to store:', data)
       this.store.set(data.id, data)
 
-      const { version, global } = await this.getVersionInfo(factory)
-      if (version) {
-        this.store.set(`${factory.id}.version`, version)
-      }
-      if (global) {
-        this.store.set(`${factory.id}.global`, global)
+      // const { version, global } = await this.getVersionInfo(factory)
+      // if (version) {
+      //   this.store.set(`${factory.id}.version`, version)
+      // }
+      if (factory.isGlobal) {
+        this.store.set(`${factory.id}.global`, factory.isGlobal)
       }
 
       return factory
@@ -269,13 +269,14 @@ export default class CommandAdd extends Command {
   }
 
   private async installProdDeps (flags: Record<string, any>, targetDir: string) {
-    const spinner = this.createSpinner('Installing dependencies...').start()
+    let spinner = this.createSpinner()
     try {
       process.env.NODE_ENV = 'production'
       const env = this.context.get('env')
-      const pm =
-        flags.packageManager ||
-        (env.hasYarn ? 'yarn' : this.context.get('config').packageManager)
+      const config = this.context.get('config')
+      const pm = flags.packageManager || (env.hasYarn ? 'yarn' : config.packageManager)
+      console.log(`fbi start install dependencies in ${this.style.cyan(targetDir)}`)
+      spinner.start(`${this.style.cyan(`${pm} install`)}`)
       await this.exec.command(`${pm} install`, {
         cwd: targetDir,
         stdout: 'ignore',
@@ -286,9 +287,7 @@ export default class CommandAdd extends Command {
       })
       spinner.succeed('Installed dependencies')
     } catch (err) {
-      spinner.fail(
-        'Failed to install dependencies. You can install them manually.'
-      )
+      spinner.fail(`Failed to install dependencies, You can install them manually, install dependencies path: ${targetDir}`)
       this.error(err)
     }
   }

--- a/src/core/base.ts
+++ b/src/core/base.ts
@@ -106,7 +106,7 @@ export abstract class BaseClass {
     return config
   }
 
-  createSpinner (str: string) {
+  createSpinner (str?: string) {
     return (str && ora(str)) || ora()
   }
 


### PR DESCRIPTION
本次改动如下：

- fbi add时，去除多余的factory模板版本创建逻辑
- createSpinner的str改为可选参数
- 优化fbi add <factory>时，安装factory依赖的文案提示